### PR TITLE
[BE] Response 및 공통 예외 처리 구현

### DIFF
--- a/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/GeneralExceptionHandler.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/GeneralExceptionHandler.java
@@ -1,0 +1,10 @@
+package com.fiveguys.robocar.apiPayload;
+
+import com.fiveguys.robocar.apiPayload.exception.GeneralException;
+
+public class GeneralExceptionHandler extends GeneralException {
+
+    public GeneralExceptionHandler(ResponseStatus status) {
+        super(status);
+    }
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/ResponseApi.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/ResponseApi.java
@@ -1,0 +1,58 @@
+package com.fiveguys.robocar.apiPayload;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseApi {
+    @Getter
+    @Builder
+    private static class Body<T> {
+        private String message;
+        private T data;
+    }
+
+    // body가 없을 경우
+    public static <T> ResponseEntity<T> of(ResponseStatus status) {
+        return new ResponseEntity(status.getMessage(), status.getHttpStatus());
+    }
+
+    public static <T> ResponseEntity<T> of(ResponseStatus status, T data) {
+        Body body = Body.builder()
+                .message(status.getMessage())
+                .data(data)
+                .build();
+        return new ResponseEntity(body, status.getHttpStatus());
+    }
+
+    // 200
+    public static <T> ResponseEntity<T> ok(T data) {
+        return of(ResponseStatus._OK, data);
+    }
+
+    public static <T> ResponseEntity<T> badRequest(T data) {
+        return of(ResponseStatus._BAD_REQUEST, data);
+    }
+
+    // 401
+    public static <T> ResponseEntity<T> unauthorized(T data) {
+        return of(ResponseStatus._UNAUTHORIZED, data);
+    }
+
+    // 403
+    public static <T> ResponseEntity<T> forbidden(T data) {
+        return of(ResponseStatus._FORBIDDEN, data);
+    }
+
+    // 409
+    public static <T> ResponseEntity<T> conflict(T data) {
+        return of(ResponseStatus._CONFLICT, data);
+    }
+
+
+    // 500
+    public static <T> ResponseEntity<T> serverError(T data) {
+        return of(ResponseStatus._INTERNAL_SERVER_ERROR, data);
+    }
+
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/ResponseApi.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/ResponseApi.java
@@ -13,7 +13,7 @@ public class ResponseApi {
     }
 
     // body가 없을 경우
-    public static <T> ResponseEntity<T> of(ResponseStatus status) {
+    public static ResponseEntity of(ResponseStatus status) {
         return new ResponseEntity(status.getMessage(), status.getHttpStatus());
     }
 

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/ResponseStatus.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/ResponseStatus.java
@@ -1,0 +1,29 @@
+package com.fiveguys.robocar.apiPayload;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseStatus {
+    _OK(org.springframework.http.HttpStatus.OK, "요청에 성공했습니다."),
+    // 가장 일반적인 응답
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "금지된 요청입니다."),
+    _CONFLICT(HttpStatus.CONFLICT, "중복된 리소스입니다."),
+    _INTERNAL_SERVER_ERROR(org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러, 관리자에게 문의 바랍니다."),
+
+    // 멤버 관려 에러 예시
+    MEMBER_NOT_FOUND(org.springframework.http.HttpStatus.BAD_REQUEST, "사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(org.springframework.http.HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
+
+    // 테스트용
+    TEST_EXCEPTION(org.springframework.http.HttpStatus.BAD_REQUEST, "Error 테스트"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/exception/GeneralException.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/apiPayload/exception/GeneralException.java
@@ -1,0 +1,17 @@
+package com.fiveguys.robocar.apiPayload.exception;
+
+import com.fiveguys.robocar.apiPayload.ResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private ResponseStatus status;
+
+    public ResponseStatus getResponseStatus() {
+        return this.status;
+    }
+
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestService.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestService.java
@@ -1,0 +1,7 @@
+package com.fiveguys.robocar.service;
+
+public interface TestService {
+
+    void CheckFlag(Integer flag);
+    
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestService.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestService.java
@@ -2,6 +2,6 @@ package com.fiveguys.robocar.service;
 
 public interface TestService {
 
-    void CheckFlag(Integer flag);
+    void checkFlag(Integer flag);
     
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestServiceImpl.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestServiceImpl.java
@@ -1,0 +1,17 @@
+package com.fiveguys.robocar.service;
+
+import com.fiveguys.robocar.apiPayload.GeneralExceptionHandler;
+import com.fiveguys.robocar.apiPayload.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestServiceImpl implements TestService {
+    @Override
+    public void CheckFlag(Integer flag) {
+        if (flag == 1)
+            throw new GeneralExceptionHandler(ResponseStatus.TEST_EXCEPTION);
+    }
+
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestServiceImpl.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/TestServiceImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TestServiceImpl implements TestService {
     @Override
-    public void CheckFlag(Integer flag) {
+    public void checkFlag(Integer flag) {
         if (flag == 1)
             throw new GeneralExceptionHandler(ResponseStatus.TEST_EXCEPTION);
     }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/swaggertest/ExampleController.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/swaggertest/ExampleController.java
@@ -1,11 +1,13 @@
 package com.fiveguys.robocar.swaggertest;
 
+import com.fiveguys.robocar.apiPayload.ResponseApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,8 +26,8 @@ public class ExampleController {
             @ApiResponse(responseCode = "400", description = "클라이언트 에러1"),
             @ApiResponse(responseCode = "500", description = "서버 에러")})
     @GetMapping("/swagger/concat")
-    public String concat(String str1, String str2) {
-        return str1 + " " + str2;
+    public ResponseEntity concat(String str1, String str2) {
+        return ResponseApi.ok(str1 + str2);
     }
 
     @Operation(summary = "문자열 복사하기") // 메소드 설명
@@ -34,14 +36,14 @@ public class ExampleController {
             @ApiResponse(responseCode = "400", description = "클라이언트 에러1"),
             @ApiResponse(responseCode = "500", description = "서버 에러")})
     @GetMapping("/swagger/copy")
-    public String copy(@RequestBody ExamDto examDto) {
-        return examDto.getName() + examDto.getAge();
+    public ResponseEntity copy(@RequestBody ExamDto examDto) {
+        return ResponseApi.ok(examDto.getName() + examDto.getAge());
     }
 
     @Operation(summary = "pathvaliable 테스트") // 메소드 설명
     @Parameter(name = "id", description = "아이디")
     @GetMapping("/swagger/{id}")
-    public String copy(@PathVariable Long id) {
-        return id.toString();
+    public ResponseEntity copy(@PathVariable String id) {
+        return ResponseApi.ok(id);
     }
 }


### PR DESCRIPTION
## ✏️ 작업 및 변경사항 설명
> 응답 및 예외 처리 방식을 통일하기 위한 ResponseApi와 GeneralExceptionHandler 구현
<br>

## 📝 작업 목록
- [x] ResponseApi를 통한 Response를 return하는 방식 통일
- [x] GeneralExceptionHandler를 통한 RuntimeException 예외 처리 구현
- [x] ResponseApi 도입으로 인한 Swagger 예시 컨트롤러의 return 값 수정
<br>

## ✅ 체크 리스트
- [x] dev 브랜치에 pr을 날렸는가?
- [ ] 테스트 코드를 작성했는가?
- [x] 리뷰어, 라벨, 프로젝트, 마일스톤을 추가하였는가?
<br>

## 참고사항
> 1. ResponseApi  
> - 많이 사용하는 response 상태에 대해서는 파라미터로 data만 넣어서 사용할 수 있도록 구현
> - 추가로 필요한 response 상태는 of를 사용해서 직접 넣을 수 있고 ResponseStatus에 추가하여 재사용할 수 있다.
``` java
public class ResponseApi {

    // body가 없을 경우
    public static <T> ResponseEntity<T> of(ResponseStatus status) {
        return new ResponseEntity(status.getMessage(), status.getHttpStatus());
    }

    public static <T> ResponseEntity<T> of(ResponseStatus status, T data) {
        Body body = Body.builder()
                .message(status.getMessage())
                .data(data)
                .build();
        return new ResponseEntity(body, status.getHttpStatus());
    }

    // 200
    public static <T> ResponseEntity<T> ok(T data) {
        return of(ResponseStatus._OK, data);
    }

    // 401
    public static <T> ResponseEntity<T> unauthorized(T data) {
        return of(ResponseStatus._UNAUTHORIZED, data);
    }

```

> 2. 빈번히 일어나는 RuntimeException을 추상화
> - 미리 구현한 예외 상태(ResponseStatus, 상태 코드 및 메시지)를 이용하여 간단하게 처리할 수 있도록 구현