### PR TITLE
[AOS] 로그인 레이아웃 구현

### DIFF
--- a/AOS/app/src/main/AndroidManifest.xml
+++ b/AOS/app/src/main/AndroidManifest.xml
@@ -12,15 +12,17 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.RoboCar"
         tools:targetApi="31">
-
         <activity
-            android:name="org.softeer.robocar.ui.activity.HomeActivity"
+            android:name=".ui.activity.HomeActivity"
             android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.activity.LoginActivity"
+            android:exported="false"/>
     </application>
 
 </manifest>

--- a/AOS/app/src/main/java/org/softeer/robocar/ui/activity/LoginActivity.kt
+++ b/AOS/app/src/main/java/org/softeer/robocar/ui/activity/LoginActivity.kt
@@ -1,0 +1,19 @@
+package org.softeer.robocar.ui.activity
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import org.softeer.robocar.R
+import org.softeer.robocar.databinding.ActivityLoginBinding
+import org.softeer.robocar.utils.setStatusBarTransparent
+
+class LoginActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityLoginBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_login)
+        setStatusBarTransparent(window)
+    }
+}

--- a/AOS/app/src/main/java/org/softeer/robocar/ui/custom/BackPressClearFocusEditText.kt
+++ b/AOS/app/src/main/java/org/softeer/robocar/ui/custom/BackPressClearFocusEditText.kt
@@ -1,0 +1,20 @@
+package org.softeer.robocar.ui.custom
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.KeyEvent
+import androidx.appcompat.widget.AppCompatEditText
+
+class BackPressClearFocusEditText : AppCompatEditText {
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    override fun onKeyPreIme(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            clearFocus()
+        }
+        return super.onKeyPreIme(keyCode, event)
+    }
+}

--- a/AOS/app/src/main/java/org/softeer/robocar/ui/custom/BackPressClearFocusEditText.kt
+++ b/AOS/app/src/main/java/org/softeer/robocar/ui/custom/BackPressClearFocusEditText.kt
@@ -3,6 +3,7 @@ package org.softeer.robocar.ui.custom
 import android.content.Context
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.inputmethod.EditorInfo
 import androidx.appcompat.widget.AppCompatEditText
 
 class BackPressClearFocusEditText : AppCompatEditText {
@@ -10,6 +11,15 @@ class BackPressClearFocusEditText : AppCompatEditText {
     constructor(context: Context) : super(context)
 
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    init {
+        setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                clearFocus()
+            }
+            false
+        }
+    }
 
     override fun onKeyPreIme(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK) {

--- a/AOS/app/src/main/res/drawable/rectangle_gray_150_radius_12.xml
+++ b/AOS/app/src/main/res/drawable/rectangle_gray_150_radius_12.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+
+    <corners android:radius="12dp"/>
+    <solid android:color="@color/gray_150"/>
+
+</shape>

--- a/AOS/app/src/main/res/layout/activity_login.xml
+++ b/AOS/app/src/main/res/layout/activity_login.xml
@@ -37,7 +37,7 @@
             android:fontFamily="@font/pretendard_semibold"
             android:textColor="@color/black"
             android:background="@drawable/rectangle_gray_150_radius_12"
-            android:maxLines="1"
+            android:inputType="text"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/logo"/>
@@ -58,7 +58,6 @@
             android:textColor="@color/black"
             android:background="@drawable/rectangle_gray_150_radius_12"
             android:inputType="textPassword"
-            android:maxLines="1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/idInputText"/>

--- a/AOS/app/src/main/res/layout/activity_login.xml
+++ b/AOS/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+
+    </data>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white">
+
+        <!-- 로고는 수정 예정 -->
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="RoboCar"
+            android:fontFamily="@font/pretendard_semibold"
+            android:textSize="@dimen/logo_text"
+            android:layout_marginTop="80dp"
+            android:textColor="@color/hyundai_blue"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <org.softeer.robocar.ui.custom.BackPressClearFocusEditText
+            android:id="@+id/idInputText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/id_placeholder"
+            android:layout_marginTop="24dp"
+            android:layout_marginStart="@dimen/default_left_margin"
+            android:layout_marginEnd="@dimen/default_right_margin"
+            android:paddingStart="@dimen/default_left_margin"
+            android:paddingEnd="@dimen/default_right_margin"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:fontFamily="@font/pretendard_semibold"
+            android:textColor="@color/black"
+            android:background="@drawable/rectangle_gray_150_radius_12"
+            android:maxLines="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/logo"/>
+
+        <org.softeer.robocar.ui.custom.BackPressClearFocusEditText
+            android:id="@+id/passwordInputText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/password_placeholder"
+            android:layout_marginTop="12dp"
+            android:layout_marginStart="@dimen/default_left_margin"
+            android:layout_marginEnd="@dimen/default_right_margin"
+            android:paddingStart="@dimen/default_left_margin"
+            android:paddingEnd="@dimen/default_right_margin"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:fontFamily="@font/pretendard_semibold"
+            android:textColor="@color/black"
+            android:background="@drawable/rectangle_gray_150_radius_12"
+            android:inputType="textPassword"
+            android:maxLines="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/idInputText"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/waringMessage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_warning_message"
+            android:textColor="@color/red_200"
+            android:textSize="@dimen/content_text"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/passwordInputText"/>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/loginButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="@dimen/default_left_margin"
+            android:layout_marginEnd="@dimen/default_right_margin"
+            android:background="@drawable/rectangle_hyundai_blue_radius_12"
+            android:textColor="@color/white"
+            android:textSize="@dimen/title_text"
+            android:text="@string/login"
+            android:fontFamily="@font/pretendard_semibold"
+            app:layout_constraintTop_toBottomOf="@id/waringMessage"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/sign_up"
+            android:textSize="@dimen/content_text"
+            android:fontFamily="@font/pretendard_regular"
+            android:layout_marginEnd="@dimen/default_right_margin"
+            android:background="?attr/selectableItemBackground"
+            android:textColor="@color/black"
+            app:layout_constraintTop_toBottomOf="@id/loginButton"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/AOS/app/src/main/res/values/colors.xml
+++ b/AOS/app/src/main/res/values/colors.xml
@@ -12,11 +12,12 @@
     <color name="gray_900">#666666</color>
     <color name="gray_800">#888888</color>
     <color name="gray_700">#999999</color>
-    <color name="gray_500">#F5F5F5</color>
     <color name="gray_600">#CCCCCC</color>
+    <color name="gray_500">#D9D9D9</color>
     <color name="gray_400">#E9E9E9</color>
     <color name="gray_300">#ECECEC</color>
     <color name="gray_200">#F3F3F3</color>
+    <color name="gray_150">#F5F5F5</color>
     <color name="gray_100">#F8F8F8</color>
     <color name="red_200">#FF6B6B</color>
     <color name="yellow_200">#FFB240</color>

--- a/AOS/app/src/main/res/values/strings.xml
+++ b/AOS/app/src/main/res/values/strings.xml
@@ -13,4 +13,9 @@
     <string name="modify_user_password">비밀번호 변경</string>
     <string name="withdrawal"><u>회원탈퇴</u></string>
     <string name="logout"><u>로그아웃</u></string>
+    <string name="id_placeholder">아이디를 입력하세요.</string>
+    <string name="password_placeholder">비밀번호를 입력하세요.</string>
+    <string name="login">로그인</string>
+    <string name="sign_up">회원가입</string>
+    <string name="login_warning_message">로그인 실패했습니다. 다시 로그인해주세요.</string>
 </resources>


### PR DESCRIPTION
## ✏️ 작업 및 변경사항 설명
> 로그인 레이아웃 구현
<br>

## 📝 작업 목록
- [x] 로고배치
- [x] 아이디, 비밀번호 입력창 배치
- [x] 아이디, 비밀번호 placeHolder 설정
- [x] '로그인 실패했습니다. 다시 로그인해주세요.' 문구 배치
- [x] 회원가입 버튼 배치
- [x] 뒤로가기 버튼 클릭 시, editText focus 해제 기능 구현
- [x] 완료 버튼 클릭 시, editText focus 해제 기능 구현
<br>

## ✅ 체크 리스트
- [x] dev 브랜치에 pr을 날렸는가?
- [x] 리뷰어, 라벨, 마일스톤을 추가하였는가?
<br>

## 참고사항
> 코드 설명 및 참고 자료

https://github.com/softeerbootcamp-3rd/Team7-FiveGuys/assets/116520932/9da65239-fd33-4f12-a852-8d966f4c2c9d
<br>

BackPressClearFocusEditText 클래스는 editText에 텍스트를 입력한 뒤에 focus를 해제하기 위해 구현한 클래스입니다.
기본적으로 editText의 focus 상태에서 뒤로가기 버튼을 누르면, 해당 이벤트를 ime에서 먼저 소비하기 때문에 키보드만 내려가고 focus는 사라지지 않습니다. 그래서 onKeyPreIme 함수에 뒤로가기 버튼을 눌렀을 시에 focus를 제거하는 기능을 구현했습니다. 그리고 비밀번호 입력 후 '완료' 버튼을 눌러도 키보드만 내려가고 focus가 해제되지 않는데, 이를 해결하기 위해 setOnEditorActionListener에 '완료' 버튼이 눌린 경우 focus를 제거하는 기능을 구현했습니다.
