### PR TITLE
[BE] JwtAuthenticationFIlter 버그 해결

### DIFF
--- a/BE/robocar/src/main/java/com/fiveguys/robocar/auth/Auth.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/auth/Auth.java
@@ -1,4 +1,4 @@
-package com.fiveguys.robocar.controller.annotation;
+package com.fiveguys.robocar.auth;
 
 import io.swagger.v3.oas.annotations.Parameter;
 

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/auth/AuthArgumentResolver.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/auth/AuthArgumentResolver.java
@@ -1,7 +1,7 @@
-package com.fiveguys.robocar.controller.resolver;
+package com.fiveguys.robocar.auth;
 
 
-import com.fiveguys.robocar.controller.annotation.Auth;
+import com.fiveguys.robocar.auth.Auth;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/auth/RequestMappings.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/auth/RequestMappings.java
@@ -17,6 +17,10 @@ public class RequestMappings {
         return customRequestMappingList.contains(new CustomRequestMapping(url, method));
     }
 
+    private static ArrayList<CustomRequestMapping> newEmptyArrayList() {
+        return new ArrayList<>();
+    }
+
     @Getter
     @AllArgsConstructor
     public static class CustomRequestMapping {
@@ -31,9 +35,5 @@ public class RequestMappings {
             }
             return false;
         }
-
-    }
-    private static ArrayList<CustomRequestMapping> newEmptyArrayList() {
-        return new ArrayList<>();
     }
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/auth/RequestMappings.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/auth/RequestMappings.java
@@ -1,0 +1,39 @@
+package com.fiveguys.robocar.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RequestMappings {
+    private List<CustomRequestMapping> customRequestMappingList = newEmptyArrayList();
+
+    public void add(String url, String method) {
+        customRequestMappingList.add(new CustomRequestMapping(url, method));
+    }
+
+    public boolean contains(String url, String method) {
+        return customRequestMappingList.contains(new CustomRequestMapping(url, method));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CustomRequestMapping {
+
+        private String url;
+        private String method;
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof CustomRequestMapping) {
+                return ((CustomRequestMapping) obj).getUrl().equals(url)
+                        && ((CustomRequestMapping) obj).getMethod().equals(method);
+            }
+            return false;
+        }
+
+    }
+    private static ArrayList<CustomRequestMapping> newEmptyArrayList() {
+        return new ArrayList<>();
+    }
+}

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/config/WebConfig.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/config/WebConfig.java
@@ -1,8 +1,6 @@
 package com.fiveguys.robocar.config;
 
-import com.fiveguys.robocar.controller.resolver.AuthArgumentResolver;
-import com.fiveguys.robocar.util.JwtUtil;
-import lombok.RequiredArgsConstructor;
+import com.fiveguys.robocar.auth.AuthArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/controller/JwtController.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/controller/JwtController.java
@@ -1,7 +1,7 @@
 package com.fiveguys.robocar.controller;
 
 import com.fiveguys.robocar.apiPayload.ResponseApi;
-import com.fiveguys.robocar.controller.annotation.Auth;
+import com.fiveguys.robocar.auth.Auth;
 import com.fiveguys.robocar.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/controller/PaymentController.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/controller/PaymentController.java
@@ -1,7 +1,7 @@
 package com.fiveguys.robocar.controller;
 
 import com.fiveguys.robocar.apiPayload.ResponseApi;
-import com.fiveguys.robocar.controller.annotation.Auth;
+import com.fiveguys.robocar.auth.Auth;
 import com.fiveguys.robocar.dto.PaymentFailDto;
 import com.fiveguys.robocar.dto.PaymentSuccessDto;
 import com.fiveguys.robocar.dto.req.PaymentReqDto;


### PR DESCRIPTION
## ✏️ 작업 및 변경사항 설명
> 같은 url에 여러 메소드가 존재할 때 jwt 필터링이 되지 않는 문제 해결
<br>

## 📝 작업 목록
- [x] Auth 관련 코드를 robocar/auth 디렉토리로 변경
- [x] RequestMappings 일급 컬렉션 구현
- [x] RequestMappings 도입으로 인한 AuthRequestMappingScanner, JwtAuthenticationFilter 수정
<br>

## ✅ 체크 리스트
- [x] dev 브랜치에 pr을 날렸는가?
- [x] 리뷰어를 추가하였는가?
<br>

## 참고사항
> 1. RequestMappings
> request를 url로만 필터링 하면 메소드를 구분하지 못하기 때문에 url, method를 모두 구분하기 위한 객체 구현
> 내부적으로 CustomRequestMapping class가 존재
> ``` java
>    public static class CustomRequestMapping {
>        private String url;
>        private String method;
>        @Override
>        public boolean equals(Object obj) {
>            if (obj instanceof CustomRequestMapping) {
>                return ((CustomRequestMapping) obj).getUrl().equals(url)
>                        && ((CustomRequestMapping) obj).getMethod().equals(method);
>            }
>            return false;
>        }
>    }
> ```
>RequestMappings은 List<CustomRequestMapping> customRequestMappingList를 관리하기 위한 메소드를 제공한다.
> ``` java
> public class RequestMappings {
>    private List<CustomRequestMapping> customRequestMappingList = newEmptyArrayList();
>
>    public void add(String url, String method) {
>        customRequestMappingList.add(new CustomRequestMapping(url, method));
>    }
>
>    public boolean contains(String url, String method) {
>        return customRequestMappingList.contains(new CustomRequestMapping(url, method));
>    }
> }
> ```


Resolve #87 