### PR TITLE
[BE] 로그인시 FCM토큰 저장

### DIFF
--- a/BE/robocar/src/main/java/com/fiveguys/robocar/dto/req/UserLoginReqDto.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/dto/req/UserLoginReqDto.java
@@ -17,4 +17,8 @@ public class UserLoginReqDto {
     @Size(max = 50)
     @NotBlank
     String password;
+
+    @Size(max = 100)
+    @NotBlank
+    String FCMToken;
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/entity/User.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/entity/User.java
@@ -21,7 +21,7 @@ public class User {
 
     private String password;
 
-    private String clientToken;
+    private String FCMToken;
 
     public void editNickname(String nickname){
         this.nickname = nickname;
@@ -30,4 +30,6 @@ public class User {
     public void editPassword(String password) {
         this.password = password;
     }
+
+    public void editClientToken(String clientToken){this.FCMToken = clientToken; }
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/UserService.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/UserService.java
@@ -86,7 +86,7 @@ public class UserService {
         userRepository.deleteById(id);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public LoginResDto userLogin(UserLoginReqDto userLoginReqDto) {
         String loginId = userLoginReqDto.getLoginId();
         String password = userLoginReqDto.getPassword();

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/UserService.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/UserService.java
@@ -90,11 +90,15 @@ public class UserService {
     public LoginResDto userLogin(UserLoginReqDto userLoginReqDto) {
         String loginId = userLoginReqDto.getLoginId();
         String password = userLoginReqDto.getPassword();
+        String FCMToken = userLoginReqDto.getFCMToken();
 
         User user = userRepository.findByLoginId(loginId).orElseThrow(()->new EntityNotFoundException(ResponseStatus.MEMBER_NOT_FOUND.getMessage()));
 
+        user.editClientToken(FCMToken);
+
         if(!user.getLoginId().equals(loginId) || !user.getPassword().equals(password))
             throw new EntityNotFoundException(ResponseStatus.USER_WRONG_PASSWORD.getMessage());
+        userRepository.save(user);
         String token = jwtUtil.createToken(user.getId());
         String nickname = user.getNickname();
         Long id = user.getId();


### PR DESCRIPTION
## ✏️ 작업 및 변경사항 설명
 > 안드로이드에서 테스트 할 수 있도록 FCM토큰을 저장할 수 있도록 코드를 수정했습니다
<br>

## 📝 작업 목록
- [x] USER 엔티티에서 clientToken명을 FCMToken으로 수정
- [x] UserService에서 로그인시 FCMToken값도 저장 되도록 로그인 서비스 수정
<br>

## ✅ 체크 리스트
- [x] dev 브랜치에 pr을 날렸는가?
- [x] 리뷰어를 추가하였는가?
<br>

## 참고사항
> 단순히 저장하는 기능 추가와 필드명 수정만 했습니다.
<img width="786" alt="image" src="https://github.com/softeerbootcamp-3rd/Team7-FiveGuys/assets/62013201/5f26c91b-e426-43e7-af59-9daa67b8a397">
