### PR TITLE
[BE] 점유를 위한 Lock과  Redis의 TTL 추가

### DIFF
--- a/BE/robocar/src/main/java/com/fiveguys/robocar/controller/OperationController.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/controller/OperationController.java
@@ -63,7 +63,7 @@ public class OperationController {
     public HttpEntity carpoolReject(@Auth Long hostId, @RequestParam Long guestId) throws JSONException {
         String response = null;
         try {
-            response = fcmService.pushCarpoolReject(guestId);
+            response = fcmService.pushCarpoolReject(guestId, hostId);
         } catch (EntityNotFoundException e) {
             return ResponseApi.of(ResponseStatus.MEMBER_NOT_FOUND);
         } catch (NoSuchElementException e) {

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/converter/CarpoolRegisterParser.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/converter/CarpoolRegisterParser.java
@@ -58,6 +58,8 @@ public class CarpoolRegisterParser {
                 .femaleCount(femaleCount)
                 .carType(carType)
                 .carId(carId)
+                .isLocked(false)
+                .timeToLive(3600L)
                 .build();
         return carpoolRequest;
     }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/entity/CarpoolRequest.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/entity/CarpoolRequest.java
@@ -35,4 +35,7 @@ public class CarpoolRequest {
 
     @TimeToLive()
     private Long timeToLive;
+
+    public void lock(){isLocked=true;}
+    public void unlock(){isLocked=false;}
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/entity/CarpoolRequest.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/entity/CarpoolRequest.java
@@ -5,6 +5,7 @@ import org.springframework.data.annotation.Id;
 
 import lombok.*;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
 @RedisHash("CarpoolRequest")
 @Getter
@@ -27,7 +28,11 @@ public class CarpoolRequest {
     private Integer maleCount;
     private Integer femaleCount;
 
-    private CarType carType;
     private Long carId;
+    private CarType carType;
 
+    boolean isLocked;
+
+    @TimeToLive()
+    private Long timeToLive;
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/service/OperationService.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/service/OperationService.java
@@ -176,11 +176,10 @@ public class OperationService {
 //                .estimatedGuestArrivalTime()
                 .build();
 
-        //리턴값 필요함( 호스트에게 )
         Long inOperationId = inOperationRepository.save(inOperation).getId();
 
         firebaseCloudMessageService.pushCarpoolAccept(guestId,inOperationId);
-        // 삭제 전, 락 해제해야 할 수도 있음
+
         carpoolRequestRepository.deleteById(String.valueOf(id));
 
         return inOperationId;
@@ -193,8 +192,7 @@ public class OperationService {
         carpoolRequestRepository.deleteById(String.valueOf(id));
         Car car = carRepository.findById(carpoolRequest.getCarId()).orElseThrow(Exception::new);
         car.editCarState(CarState.READY);
-        //TODO
-        // 락 해제
+
         carRepository.save(car);
     }
 }

--- a/BE/robocar/src/main/java/com/fiveguys/robocar/util/CreateCarpoolListUpResDto.java
+++ b/BE/robocar/src/main/java/com/fiveguys/robocar/util/CreateCarpoolListUpResDto.java
@@ -57,6 +57,8 @@ public class CreateCarpoolListUpResDto {
         for(CarpoolRequest req : iterableRequests){
             if(req == null)
                 continue;
+            if(req.isLocked())
+                continue;
 
             hostDepartCoordinate = String.format("%f,%f",req.getDepartLongitude(),req.getDepartLatitude());
 

--- a/BE/robocar/src/test/java/com/fiveguys/robocar/service/OperationServiceTest.java
+++ b/BE/robocar/src/test/java/com/fiveguys/robocar/service/OperationServiceTest.java
@@ -72,6 +72,8 @@ class OperationServiceTest {
                 .femaleCount(0)
                 .carType(CarType.SMALL)
                 .carId(3L)
+                .isLocked(false)
+                .timeToLive(360000L)
                 .build();
         service.saveCarpoolRequest(carpoolRequest);
         service.saveCarpoolRequest(carpoolRequest2);


### PR DESCRIPTION
## ✏️ 작업 설명
> CarpoolRequest에서 동승자와 교류중일 때는 Lock을 걸어 다른 알림이 오지 않도록 했습니다.
> 추가로 Redis 메모리에 영구적으로 쌓이는 데이터가 없도록 TTL을 1시간으로 설정하였습니다.
<br>

## 📝 작업 목록
- [ ] 관련 필드값 생성
- [ ] 기존에 있던 메소드들 수정
- [ ] 테스트
<br>

## ⏰ 예상 소요 시간
> 3시간
<br>

## 참고사항 (선택)
> 추가로 노션에 참고할 수 있는 자료를 남겨두었습니다.
> TTL은 아래와 같이 확인 할 수 있습니다
![image](https://github.com/softeerbootcamp-3rd/Team7-FiveGuys/assets/62013201/d907c600-3f2e-4ea7-8175-71220c2ecea2)


